### PR TITLE
Fix #8 (Warning: Invalid DOM property `tabindex`. Did you mean `tabIndex`?)

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,7 +40,7 @@ class Navbar extends React.Component {
                     <a
                       className="nav-link disabled"
                       href="/vee/not-gae"
-                      tabindex="-1"
+                      tabIndex="-1"
                       aria-disabled="true"
                     >
                       if you can click this vee is not gae


### PR DESCRIPTION
Fixes #8 